### PR TITLE
Add timeout for requests internal call

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Anyway there is good tutorial about <a href="http://gun.io/blog/how-to-github-fo
 
 ## Usage
 
-Well, There is an example to Send SMS by Python below.
+Well, There is an example to Send SMS by Python below. `timeout` parameter is optional in `KavenegarAPI` constructor, default value is set to 10 seconds.
 
 ### Send
 ```python
 from kavenegar import *
 try:
-    api = KavenegarAPI('Your APIKey')
+    api = KavenegarAPI('Your APIKey', timeout=20)
     params = {
         'sender': '',#optional
         'receptor': '',#multiple mobile number, split by comma
@@ -46,7 +46,7 @@ except HTTPException as e:
 #!/usr/bin/env python
 from kavenegar import *
 try:
-    api = KavenegarAPI('Your APIKey')
+    api = KavenegarAPI('Your APIKey', timeout=20)
     params = {
         'receptor': '',
         'template': '',
@@ -65,7 +65,7 @@ except HTTPException as e:
 #!/usr/bin/env python
 from kavenegar import *
 try:
-    api = KavenegarAPI('Your APIKey')
+    api = KavenegarAPI('Your APIKey', timeout=20)
     params = {
         'sender':'["",""]',#array of string as json 
         'receptor': '["",""]',#array of string as json 

--- a/kavenegar.py
+++ b/kavenegar.py
@@ -5,6 +5,11 @@ try:
 except ImportError:
     import simplejson as json
 
+
+# Default requests timeout in seconds.
+DEFAULT_TIMEOUT = 10
+
+
 class APIException(Exception):
     pass
 
@@ -12,10 +17,11 @@ class HTTPException(Exception):
     pass
 
 class KavenegarAPI(object):
-    def __init__(self, apikey):
+    def __init__(self, apikey, timeout=None):
         self.version = 'v1'
         self.host = 'api.kavenegar.com'
         self.apikey = apikey
+        self.timeout = timeout or DEFAULT_TIMEOUT
         self.headers = {
 	    'Accept': 'application/json',
 	    'Content-Type': 'application/x-www-form-urlencoded',
@@ -31,7 +37,7 @@ class KavenegarAPI(object):
     def _request(self, action, method, params={}):
         url = 'https://' + self.host + '/' + self.version + '/' + self.apikey + '/' + action + '/' + method + '.json'
         try:
-            content = requests.post(url , headers=self.headers,auth=None,data=params).content
+            content = requests.post(url , headers=self.headers,auth=None,data=params, timeout=self.timeout).content
             try:
                 response = json.loads(content.decode("utf-8"))
                 if (response['return']['status']==200):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if sys.version_info < (2, 6):
 setup(
     name = "kavenegar",
     py_modules = ['kavenegar'],
-    version = "1.1.1",
+    version = "1.1.3",
     description = "Kavenegar Python library",
     author = "Kavenegar Team",
     author_email = "support@kavenegar.com",


### PR DESCRIPTION
There was no timeout parameter for `requests.post` call and it could cause some issues.